### PR TITLE
logger statt Serial.print

### DIFF
--- a/Pflanzensensor/analogsensor.h
+++ b/Pflanzensensor/analogsensor.h
@@ -11,6 +11,8 @@
 #ifndef ANALOGSENSOR_H
 #define ANALOGSENSOR_H
 
+#include "logger.h"
+
 /**
  * @brief Misst den Wert eines Analogsensors und berechnet den Prozentwert
  *
@@ -40,9 +42,7 @@ std::pair<int, int> AnalogsensorMessen(
     int messwert = analogRead(pinAnalog); // Messwert einlesen
     // Messwert in Prozent umrechnen:
     int messwertProzent = map(messwert, minimum, maximum, 0, 100); // Skalierung auf maximal 0 bis 100
-    Serial.print(sensorname); Serial.print(F(": ")); Serial.print(messwertProzent);
-    Serial.print(F("%       (Messwert: ")); Serial.print(messwert);
-    Serial.println(F(")"));
+    logger.info(sensorname + ": " + String(messwertProzent) + "%       (Messwert: " + String(messwert));
     return std::make_pair(messwert, messwertProzent);
 }
 

--- a/Pflanzensensor/dht.h
+++ b/Pflanzensensor/dht.h
@@ -15,6 +15,8 @@
 #include <DHT.h> // DHT Sensor Library
 #include <DHT_U.h> // DHT Unified Sensor Library
 
+#include "logger.h"
+
 DHT_Unified dht(dhtPin, dhtSensortyp); // DHT Sensor initialisieren
 
 /**
@@ -26,22 +28,19 @@ DHT_Unified dht(dhtPin, dhtSensortyp); // DHT Sensor initialisieren
  * @return float Gemessene Luftfeuchtigkeit in Prozent, oder -1 bei Messfehler
  */
 float DhtMessenLuftfeuchte() { // Luftfeuchte messen
-  #if MODUL_DEBUG // Debuginformation
-    Serial.println(F("## Debug: Beginn von DhtMessenLuftfeuchte()"));
-    Serial.print(F("DHT PIN: ")); Serial.println(dhtPin);
-    Serial.print(F("DHT Sensortyp: ")); Serial.println(dhtSensortyp);
-  #endif
+  logger.debug("## Debug: Beginn von DhtMessenLuftfeuchte()");
+  logger.debug("DHT PIN: " + String(dhtPin));
+  logger.debug("DHT Sensortyp: "+ String(dhtSensortyp));
+
   sensors_event_t event; // Event für die Messung
   float luftfeuchte = -1; // Variable für die Luftfeuchte
   dht.humidity().getEvent(&event); // Messung der Luftfeuchte
   // überprüfen ob die Messung erfolgreich war:
   if (isnan(event.relative_humidity)) { // überprüfen ob die Messung erfolgreich war
-    Serial.println(F("Luftfeuchtemessung nicht erfolgreich! :-("));
+    logger.error("Luftfeuchtemessung nicht erfolgreich! :-(");
   }
   else {
-    Serial.print(F("Luftfeuchte: "));
-    Serial.print(event.relative_humidity);
-    Serial.println(F("%"));
+    logger.info("Luftfeuchte: " + String(event.relative_humidity) + "%");
     luftfeuchte = event.relative_humidity; // Luftfeuchte in Prozent
   }
   return luftfeuchte; // Luftfeuchte zurückgeben
@@ -58,22 +57,18 @@ float DhtMessenLuftfeuchte() { // Luftfeuchte messen
  * @return float Gemessene Lufttemperatur in °C, oder -1 bei Messfehler
  */
 float DhtMessenLufttemperatur() { // Lufttemperatur messen
-#if MODUL_DEBUG
-  Serial.println(F("## Debug: Beginn von DhtMessenLufttemperatur()"));
-  Serial.print(F("DHT PIN: ")); Serial.println(dhtPin);
-  Serial.print(F("DHT Sensortyp: ")); Serial.println(dhtSensortyp);
-#endif
+  logger.debug("## Debug: Beginn von DhtMessenLufttemperatur()");
+  logger.debug("DHT PIN: " + String(dhtPin));
+  logger.debug("DHT Sensortyp: " + String(dhtSensortyp));
+
   sensors_event_t event; // Event für die Messung
   float lufttemperatur = -1; // Variable für die Lufttemperatur
   dht.temperature().getEvent(&event); // Messung der Lufttemperatur
   if (isnan(event.temperature)) { // überprüfen ob die Messung erfolgreich war
-    Serial.println(F("Temperaturmessung nicht erfolgreich! :-("));
+    logger.error("Temperaturmessung nicht erfolgreich! :-(");
   }
   else {
-    Serial.print(F("Lufttemperatur: "));
-    Serial.print(event.temperature);
-    Serial.println(F("°C"));
-    lufttemperatur = event.temperature; // Lufttemperatur in °C
+    logger.info("Lufttemperatur: " + String(event.temperature) + "°C");
   }
   return lufttemperatur; // Lufttemperatur zurückgeben
 }

--- a/Pflanzensensor/display.h
+++ b/Pflanzensensor/display.h
@@ -19,6 +19,8 @@
 Adafruit_SSD1306 display(displayBreite, displayHoehe, &Wire, displayReset);
 
 #include "display_bilder.h"
+#include "logger.h"
+
 
 // Vorwärtsdeklarationen
 void ZeigeFabmobilLogo();
@@ -103,7 +105,7 @@ void NaechsteSeite() {
  */
 void DisplaySetup() {
   if(!display.begin(SSD1306_SWITCHCAPVCC, displayAdresse)) {
-    Serial.println(F("Fehler: Display konnte nicht geöffnet werden."));
+    logger.error("Fehler: Display konnte nicht geöffnet werden.");
     return;
   }
 

--- a/Pflanzensensor/einstellungen.h
+++ b/Pflanzensensor/einstellungen.h
@@ -15,7 +15,6 @@
  * Module
  * "true" aktiviert sie, "false" deaktiviert sie
  */
-#define MODUL_DEBUG         false  // Debugausgaben (de)aktivieren
 #define MODUL_DISPLAY       true  // hat dein Pflanzensensor ein Display?
 #define MODUL_WIFI          true // verwendet dein Pflanzensensor das WiFi-Modul?
 #define MODUL_DHT           true // hat dein Pflanzensensor ein Luftfeuchte- und Temperaturmesser?
@@ -32,6 +31,11 @@
 
 // Hier werden die Passwörter nachgeladen
 #include "passwoerter.h"
+
+// Einstellung für die Logs:
+#define MAX_LOG_ENTRIES 100
+#define LOG_ENTRIES_TO_DISPLAY 20
+#define FILE_LOGGING_ENABLED false
 
 // Wenn Bodenfeuchte- und Lichtsensor verwendet werden, brauchen wir auch einen Analog-Multiplexer:
 #if MODUL_BODENFEUCHTE && MODUL_HELLIGKEIT
@@ -211,6 +215,8 @@ String analog6Farbe = "rot";
 String analog7Farbe = "rot";
 String analog8Farbe = "rot";
 #define pinAnalog A0 // Analogpin
+#include "logger.h" // include the logger
+
 #if MODUL_BODENFEUCHTE
   int bodenfeuchteMesswert = -1;
   int bodenfeuchteMesswertProzent = -1;

--- a/Pflanzensensor/ledampel.h
+++ b/Pflanzensensor/ledampel.h
@@ -10,6 +10,7 @@
 
 #ifndef LEDAMPEL_H
 #define LEDAMPEL_H
+#include "logger.h"
 
 /**
  * @brief Lässt die LED-Ampel in einer bestimmten Farbe blinken
@@ -19,12 +20,9 @@
  * @param dauer Integer; Dauer eines Blinkvorgangs in Millisekunden
  */
 void LedampelBlinken(String farbe, int anzahl, int dauer) {
-  #if MODUL_DEBUG
-    Serial.println(F("# Beginn von LedampelBlinken()"));
-    Serial.print(F("# Farbe: ")); Serial.print(farbe);
-    Serial.print(F(", Anzahl: ")); Serial.print(anzahl);
-    Serial.print(F(", Dauer: ")); Serial.println(dauer);
-  #endif
+  logger.debug("# Beginn von LedampelBlinken()");
+  logger.debug("# Farbe: " + String(farbe) + ", Anzahl: "+ String(anzahl) + ", Dauer: " + String(dauer));
+
   char PIN_LED;
   digitalWrite(ampelPinRot, LOW);
   digitalWrite(ampelPinGelb, LOW);
@@ -54,11 +52,8 @@ void LedampelBlinken(String farbe, int anzahl, int dauer) {
  * @param dauer Integer; Dauer der Farbanzeige in Millisekunden. Bei -1 bleibt die LED an.
  */
 void LedampelAnzeigen(String farbe, int dauer) {
-  #if MODUL_DEBUG
-    Serial.print(F("# Beginn von LedampelAnzeigen(")); Serial.print(farbe);
-    Serial.print(F(", ")); Serial.print(dauer);
-    Serial.println(F(")"));
-  #endif
+  logger.debug("# Beginn von LedampelAnzeigen(" + String(farbe) + ", " + String(dauer) + ")");
+
   digitalWrite(ampelPinRot, LOW); // alle LEDs aus
   digitalWrite(ampelPinGelb, LOW);
   digitalWrite(ampelPinGruen, LOW);

--- a/Pflanzensensor/logger.cpp
+++ b/Pflanzensensor/logger.cpp
@@ -1,0 +1,263 @@
+/**
+ * @file Logger.cpp
+ * @brief Implementation of the Logger class with web support, indented console output, and file logging
+ */
+
+#include <LittleFS.h>
+#include "logger.h"
+#include "config.h"
+
+Logger logger(LogLevel::DEBUG, true, MAX_LOG_ENTRIES, FILE_LOGGING_ENABLED);
+
+Logger::Logger(LogLevel logLevel, bool useSerial, size_t maxEntries, bool fileLoggingEnabled)
+  : m_logLevel(logLevel),
+    m_useSerial(useSerial),
+    m_maxEntries(maxEntries),
+    m_timeClient(nullptr),
+    m_ntpInitialized(false),
+    m_fileLoggingEnabled(fileLoggingEnabled) {
+  if (m_useSerial) {
+    Serial.begin(115200);
+  }
+  if (!LittleFS.begin()) {
+    Serial.println("Failed to mount file system");
+  }
+
+  // Initialize the log entries vectors
+  for (int i = 0; i < 4; ++i) {
+    m_logEntriesByLevel[i].reserve(LOG_ENTRIES_TO_DISPLAY);
+  }
+}
+void Logger::setLogLevel(LogLevel level) {
+  m_logLevel = level;
+  debug("Log level set to: " + logLevelToString(level));
+}
+
+LogLevel Logger::getLogLevel() const {
+  return m_logLevel;
+}
+
+void Logger::debug(const String& message) {
+  log(LogLevel::DEBUG, message);
+}
+
+void Logger::info(const String& message) {
+  log(LogLevel::INFO, message);
+}
+
+void Logger::warning(const String& message) {
+  log(LogLevel::WARNING, message);
+}
+
+void Logger::error(const String& message) {
+  log(LogLevel::ERROR, message);
+}
+
+void Logger::enableFileLogging(bool enable) {
+  if (enable && !LittleFS.exists(m_logFileName)) {
+    File file = LittleFS.open(m_logFileName, "w");
+    if (file) {
+      file.println("Log file created");
+      file.close();
+    } else {
+      Serial.println("Failed to create log file");
+      return;
+    }
+  }
+
+  m_fileLoggingEnabled = enable;
+  if (enable) {
+    log(LogLevel::INFO, "File logging enabled");
+  } else {
+    log(LogLevel::INFO, "File logging disabled");
+  }
+}
+
+bool Logger::isFileLoggingEnabled() const {
+  return m_fileLoggingEnabled;
+}
+
+String Logger::getLogFileContent() const {
+  if (!m_fileLoggingEnabled) {
+    return "File logging is disabled";
+  }
+
+  if (!LittleFS.exists(m_logFileName)) {
+    return "Log file does not exist";
+  }
+
+  File file = LittleFS.open(m_logFileName, "r");
+  if (!file) {
+    return "Failed to open log file";
+  }
+
+  String content = file.readString();
+  file.close();
+  return content;
+}
+
+void Logger::clearLogFile() {
+  if (!m_fileLoggingEnabled) {
+    return;
+  }
+
+  File file = LittleFS.open(m_logFileName, "w");
+  if (file) {
+    file.close();
+  }
+}
+
+void Logger::log(LogLevel level, const String& message) {
+  if (level < m_logLevel) {
+    return;
+  }
+
+  String timestamp = getFormattedTimestamp();
+  LogEntry entry = {level, message, m_ntpInitialized ? m_timeClient->getEpochTime() : millis()};
+
+  // Add to the appropriate vector based on log level
+  m_logEntriesByLevel[static_cast<int>(level)].push_back(entry);
+
+  // Keep only the latest LOG_ENTRIES_TO_DISPLAY entries for each level
+  if (m_logEntriesByLevel[static_cast<int>(level)].size() > LOG_ENTRIES_TO_DISPLAY) {
+    m_logEntriesByLevel[static_cast<int>(level)].erase(m_logEntriesByLevel[static_cast<int>(level)].begin());
+  }
+
+  String logLevelStr = logLevelToString(level);
+  String indent = getIndent(logLevelStr);
+  String formattedMessage = timestamp + " " + indent + logLevelStr + ": " + message;
+
+  if (m_useSerial) {
+    Serial.println(formattedMessage);
+  }
+
+  if (m_fileLoggingEnabled) {
+    writeToFile(formattedMessage);
+  }
+}
+
+void Logger::writeToFile(const String& logMessage) {
+  if (!m_fileLoggingEnabled || !LittleFS.exists(m_logFileName)) {
+    return;
+  }
+
+  File file = LittleFS.open(m_logFileName, "a");
+  if (file) {
+    file.println(logMessage);
+    file.close();
+    truncateLogFileIfNeeded();
+  } else {
+    Serial.println("Failed to open log file for writing");
+  }
+}
+
+void Logger::truncateLogFileIfNeeded() {
+  File file = LittleFS.open(m_logFileName, "r");
+  if (file) {
+    if (file.size() > m_maxFileSize) {
+      String content = file.readString();
+      file.close();
+
+      int cutIndex = content.indexOf("\n", content.length() - m_maxFileSize);
+      if (cutIndex != -1) {
+        content = content.substring(cutIndex + 1);
+        File writeFile = LittleFS.open(m_logFileName, "w");
+        if (writeFile) {
+          writeFile.print(content);
+          writeFile.close();
+        }
+      }
+    } else {
+      file.close();
+    }
+  }
+}
+
+String Logger::logLevelToString(LogLevel level) const {
+  switch (level) {
+    case LogLevel::DEBUG:   return "DEBUG";
+    case LogLevel::INFO:    return "INFO ";
+    case LogLevel::WARNING: return "WARN ";
+    case LogLevel::ERROR:   return "ERROR";
+    default:                return "UNKNOWN";
+  }
+}
+
+String Logger::getIndent(const String& logLevelStr) const {
+  const int maxLength = 5; // Length of the longest log level string
+  return String(' ', maxLength - logLevelStr.length());
+}
+
+String Logger::logLevelToColor(LogLevel level) const {
+  switch (level) {
+    case LogLevel::DEBUG:   return "blue";
+    case LogLevel::INFO:    return "green";
+    case LogLevel::WARNING: return "orange";
+    case LogLevel::ERROR:   return "red";
+    default:                return "black";
+  }
+}
+
+String Logger::getLogsAsHtmlTable(size_t count) const {
+  String html = "<table class='log'><tr><th>Time</th><th>Level</th><th>Message</th></tr>";
+
+  std::vector<LogEntry> visibleEntries;
+
+  // Collect visible entries based on current log level
+  for (int i = static_cast<int>(m_logLevel); i < 4; ++i) {
+    visibleEntries.insert(visibleEntries.end(), m_logEntriesByLevel[i].begin(), m_logEntriesByLevel[i].end());
+  }
+
+  // Sort entries by timestamp (descending order)
+  std::sort(visibleEntries.begin(), visibleEntries.end(),
+    [](const LogEntry& a, const LogEntry& b) { return a.timestamp > b.timestamp; });
+
+  // Limit to count entries
+  size_t entriesToShow = std::min(count, visibleEntries.size());
+
+  for (size_t i = 0; i < entriesToShow; ++i) {
+    const auto& entry = visibleEntries[i];
+    String timestamp;
+    if (m_ntpInitialized) {
+      time_t epochTime = entry.timestamp;
+      struct tm *ptm = gmtime ((time_t *)&epochTime);
+      char buffer[32];
+      strftime(buffer, 32, "%Y-%m-%d %H:%M:%S", ptm);
+      timestamp = String(buffer);
+    } else {
+      timestamp = String(entry.timestamp / 1000) + "s";
+    }
+    html += "<tr>"
+            "<td>" + timestamp + "</td>"
+            "<td style='color: " + logLevelToColor(entry.level) + ";'>" + logLevelToString(entry.level) + "</td>"
+            "<td>" + entry.message + "</td>"
+            "</tr>";
+  }
+
+  html += "</table>";
+  return html;
+}
+
+String Logger::getFormattedTimestamp() const {
+  if (m_ntpInitialized) {
+    time_t epochTime = m_timeClient->getEpochTime();
+    struct tm *ptm = gmtime ((time_t *)&epochTime);
+    char buffer[32];
+    strftime(buffer, 32, "%Y-%m-%d %H:%M:%S", ptm);
+    return String(buffer);
+  } else {
+    return String(millis() / 1000) + "s";
+  }
+}
+
+void Logger::initNTP() {
+  m_timeClient = new NTPClient(m_ntpUDP, "pool.ntp.org", 3600, 60000);
+  m_timeClient->begin();
+  m_ntpInitialized = true;
+}
+
+void Logger::updateNTP() {
+  if (m_ntpInitialized) {
+    m_timeClient->update();
+  }
+}

--- a/Pflanzensensor/logger.h
+++ b/Pflanzensensor/logger.h
@@ -1,0 +1,195 @@
+/**
+ * @file logger.h
+ * @brief Header file for the Logger class with web support and indented console output
+ */
+
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <Arduino.h>
+#include <vector>
+#include <NTPClient.h>
+#include <WiFiUdp.h>
+#include "config.h"
+
+#ifndef MAX_LOG_ENTRIES
+#define MAX_LOG_ENTRIES 100
+#endif
+
+#ifndef LOG_ENTRIES_TO_DISPLAY
+#define LOG_ENTRIES_TO_DISPLAY 20
+#endif
+
+#ifndef FILE_LOGGING_ENABLED
+#define FILE_LOGGING_ENABLED false
+#endif
+
+/**
+ * @brief Enumeration for different log levels
+ */
+enum class LogLevel {
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+};
+
+/**
+ * @brief Structure to hold a log entry
+ */
+struct LogEntry {
+    LogLevel level;
+    String message;
+    unsigned long timestamp;
+};
+
+/**
+ * @brief Logger class for handling log messages
+ */
+class Logger {
+public:
+    /**
+     * @brief Constructor for Logger class
+     * @param logLevel Minimum log level to display
+     * @param useSerial Whether to output logs to Serial
+     * @param maxEntries Maximum number of log entries to keep in memory
+     */
+    Logger(LogLevel logLevel = LogLevel::INFO, bool useSerial = true, size_t maxEntries = MAX_LOG_ENTRIES, bool fileLoggingEnabled = FILE_LOGGING_ENABLED);
+
+    /**
+     * @brief Set the log level
+     * @param level The new log level
+     */
+    void setLogLevel(LogLevel level);
+
+    /**
+     * @brief Get the current log level
+     * @return The current log level
+     */
+    LogLevel getLogLevel() const;
+
+    /**
+     * @brief Log a debug message
+     * @param message Message to log
+     */
+    void debug(const String& message);
+
+    /**
+     * @brief Log an info message
+     * @param message Message to log
+     */
+    void info(const String& message);
+
+    /**
+     * @brief Log a warning message
+     * @param message Message to log
+     */
+    void warning(const String& message);
+
+    /**
+     * @brief Log an error message
+     * @param message Message to log
+     */
+    void error(const String& message);
+
+    /**
+     * @brief Get log entries as a formatted HTML table based on current log level
+     * @param count Number of entries to retrieve for each log level
+     * @return Formatted HTML table of log entries
+     */
+    String getLogsAsHtmlTable(size_t count = LOG_ENTRIES_TO_DISPLAY) const;
+
+    /**
+     * @brief Initialize NTP client for getting time from the internet
+     */
+    void initNTP();
+
+    /**
+     * @brief Update NTP client to keep time synchronized
+     */
+    void updateNTP();
+
+    /**
+     * @brief Enable or disable file logging
+     * @param enable True to enable file logging, false to disable
+     */
+    void enableFileLogging(bool enable);
+
+    /**
+     * @brief Check if file logging is enabled
+     * @return True if file logging is enabled, false otherwise
+     */
+    bool isFileLoggingEnabled() const;
+
+    /**
+     * @brief Get the content of the log file
+     * @return Content of the log file
+     */
+    String getLogFileContent() const;
+
+    /**
+     * @brief Clear the log file
+     */
+    void clearLogFile();
+
+private:
+    LogLevel m_logLevel;
+    bool m_useSerial;
+    size_t m_maxEntries;
+    std::vector<LogEntry> m_logEntries;
+    WiFiUDP m_ntpUDP;
+    NTPClient* m_timeClient;
+    bool m_ntpInitialized;
+    bool m_fileLoggingEnabled;
+    std::array<std::vector<LogEntry>, 4> m_logEntriesByLevel;  // Array of vectors for each log level
+    const char* m_logFileName = "/system.log";
+    const size_t m_maxFileSize = 100 * 1024;  // 100 KB
+    /**
+     * @brief Internal method to log a message
+     * @param level Log level of the message
+     * @param message Message to log
+     */
+    void log(LogLevel level, const String& message);
+
+    /**
+     * @brief Get string representation of log level
+     * @param level Log level to convert
+     * @return String representation of log level
+     */
+    String logLevelToString(LogLevel level) const;
+
+    /**
+     * @brief Get indentation for log level
+     * @param logLevelStr String representation of log level
+     * @return Indentation string
+     */
+    String getIndent(const String& logLevelStr) const;
+
+    /**
+     * @brief Get color representation of log level for HTML
+     * @param level Log level to convert
+     * @return Color string for HTML
+     */
+    String logLevelToColor(LogLevel level) const;
+
+    /**
+     * @brief Get current timestamp as a formatted string
+     * @return Formatted timestamp string
+     */
+    String getFormattedTimestamp() const;
+
+    /**
+     * @brief Write a log message to the log file
+     * @param logMessage Message to write
+     */
+    void writeToFile(const String& logMessage);
+
+    /**
+     * @brief Truncate the log file if it exceeds the maximum size
+     */
+    void truncateLogFileIfNeeded();
+};
+
+extern Logger logger;
+
+#endif // LOGGER_H

--- a/Pflanzensensor/multiplexer.h
+++ b/Pflanzensensor/multiplexer.h
@@ -19,12 +19,8 @@
  * @param c Wert für Digitaleingang C (0 oder 1)
  */
 void MultiplexerWechseln(int a, int b, int c) {
-  #if MODUL_DEBUG
-    Serial.print(F("# Beginn von MultiplexerWechseln("));
-    Serial.print(a); Serial.print(F(", "));
-    Serial.print(b); Serial.print(F(", "));
-    Serial.print(c); Serial.println(F(")"));
-  #endif
+  logger.debug("# Beginn von MultiplexerWechseln(" + String(a) + ", " + String(b) +", " + String(c) + ")");
+
   digitalWrite(multiplexerPinA, a); // Digitaleingang A setzen
   digitalWrite(multiplexerPinB, b); // Digitaleingang B setzen
   digitalWrite(multiplexerPinC, c); // Digitaleingang C setzen

--- a/Pflanzensensor/wifi_seite_admin.h
+++ b/Pflanzensensor/wifi_seite_admin.h
@@ -11,6 +11,8 @@
 #ifndef WIFI_SEITE_ADMIN_H
 #define WIFI_SEITE_ADMIN_H
 
+#include "logger.h"
+
 /**
  * @brief Sendet eine Einstellungsoption an den Webserver
  *
@@ -104,9 +106,7 @@ void sendeLinks() {
     "<ul>\n"
     "<li><a href=\"/\">zur Startseite</a></li>\n"));
 
-  #if MODUL_DEBUG
-    Webserver.sendContent_P(PSTR("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
-  #endif
+  Webserver.sendContent_P(PSTR("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
 
   Webserver.sendContent_P(PSTR(
     "<li><a href=\"https://www.github.com/Fabmobil/Pflanzensensor\" target=\"_blank\">"
@@ -121,9 +121,7 @@ void sendeLinks() {
  * @brief Generiert und sendet die Administrationsseite
  */
 void WebseiteAdminAusgeben() {
-  #if MODUL_DEBUG
-    Serial.println(F("# Beginn von WebsiteAdminAusgeben()"));
-  #endif
+  logger.debug("# Beginn von WebsiteAdminAusgeben()");
 
   Webserver.setContentLength(CONTENT_LENGTH_UNKNOWN);
   Webserver.send(200, F("text/html"), "");
@@ -302,9 +300,7 @@ void WebseiteAdminAusgeben() {
     Webserver.sendContent_P(htmlFooter);
     Webserver.client().flush();
 
-    #if MODUL_DEBUG
-      Serial.println(F("# Ende von WebsiteAdminAusgeben()"));
-    #endif
+    logger.debug("# Ende von WebsiteAdminAusgeben()");
 }
 
 #endif // WIFI_SEITE_ADMIN_H

--- a/Pflanzensensor/wifi_seite_debug.h
+++ b/Pflanzensensor/wifi_seite_debug.h
@@ -18,7 +18,6 @@
  * sendet sie als HTML-Seite an den Client.
  */
 void WebseiteDebugAusgeben() {
-  Serial.println(wifiPassword1);
   Webserver.setContentLength(CONTENT_LENGTH_UNKNOWN);
   Webserver.send(200, F("text/html"), "");
 
@@ -314,9 +313,7 @@ void WebseiteDebugAusgeben() {
     "<li><a href=\"/\">zur Startseite</a></li>\n"
     "<li><a href=\"/admin.html\">zur Administrationsseite</a></li>\n"));
 
-  #if MODUL_DEBUG
-    Webserver.sendContent(F("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
-  #endif
+  Webserver.sendContent(F("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
 
   Webserver.sendContent(F(
     "<li><a href=\"https://www.github.com/Fabmobil/Pflanzensensor\" target=\"_blank\">"

--- a/Pflanzensensor/wifi_seite_nichtGefunden.h
+++ b/Pflanzensensor/wifi_seite_nichtGefunden.h
@@ -11,6 +11,8 @@
 #ifndef WIFI_SEITE_NICHT_GEFUNDEN_H
 #define WIFI_SEITE_NICHT_GEFUNDEN_H
 
+#include "logger.h"
+
 /**
  * @brief Generiert und sendet die 404 (Nicht gefunden) Fehlerseite
  *
@@ -18,9 +20,7 @@
  * Sie sendet eine entsprechende Fehlermeldung an den Client.
  */
 void WebseiteNichtGefundenAusgeben() {
-  #if MODUL_DEBUG
-    Serial.println(F("# Beginn von WebseiteNichtGefundenAusgeben()"));
-  #endif
+  logger.debug("# Beginn von WebseiteNichtGefundenAusgeben()");
 
   Webserver.setContentLength(CONTENT_LENGTH_UNKNOWN);
   Webserver.send(404, F("text/html"), "");
@@ -38,9 +38,7 @@ void WebseiteNichtGefundenAusgeben() {
   Webserver.sendContent_P(htmlFooter);
   Webserver.client().flush();
 
-  #if MODUL_DEBUG
-    Serial.println(F("# Ende von WebseiteNichtGefundenAusgeben()"));
-  #endif
+  logger.debug("# Ende von WebseiteNichtGefundenAusgeben()");
 }
 
 #endif // WIFI_SEITE_NICHT_GEFUNDEN_H

--- a/Pflanzensensor/wifi_seite_setzeVariablen.h
+++ b/Pflanzensensor/wifi_seite_setzeVariablen.h
@@ -12,6 +12,8 @@
 #ifndef WIFI_SEITE_SETZE_VARIABLEN_H
 #define WIFI_SEITE_SETZE_VARIABLEN_H
 
+#include "logger.h"
+
 // Funktionsdeklarationen
 void ArgumenteAusgeben();
 void WebseiteSetzeVariablen();
@@ -27,12 +29,10 @@ void AktualisiereString(const String& argName, String& wert, bool istWLANEinstel
  * Diese Funktion ist nützlich für das Debugging von Formulareingaben.
  */
 void ArgumenteAusgeben() {
-  Serial.println(F("Gebe alle Argumente des POST requests aus:"));
+  logger.info("Gebe alle Argumente des POST requests aus:");
   int numArgs = Webserver.args();
   for (int i = 0; i < numArgs; i++) {
-    Serial.print(Webserver.argName(i));
-    Serial.print(F(": "));
-    Serial.println(Webserver.arg(i));
+    logger.info(String(Webserver.argName(i)) + ": " + String(Webserver.arg(i)));
   }
 }
 
@@ -45,10 +45,8 @@ void ArgumenteAusgeben() {
  * einschließlich Änderungen am WLAN-Modus und Checkboxen.
  */
 void WebseiteSetzeVariablen() {
-    #if MODUL_DEBUG
-        Serial.println(F("# Beginn von WebseiteSetzeVariablen()"));
-        ArgumenteAusgeben();
-    #endif
+    Serial.println(F("# Beginn von WebseiteSetzeVariablen()"));
+
     millisVorherWebhook = millisAktuell; // Webhook löst sonst sofort aus und gemeinsam mit dem Variablen setzen führt dazu, dass der ESP abstürzt.
 
     Webserver.setContentLength(CONTENT_LENGTH_UNKNOWN);
@@ -193,9 +191,8 @@ void WebseiteSetzeVariablen() {
             "<li><a href=\"/\">zur Startseite</a></li>\n"
             "<li><a href=\"/admin.html\">zur Administrationsseite</a></li>\n"
         ));
-        #if MODUL_DEBUG
-            Webserver.sendContent(F("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
-        #endif
+        Webserver.sendContent(F("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
+
         Webserver.sendContent(F(
             "<li><a href=\"https://www.github.com/Fabmobil/Pflanzensensor\" target=\"_blank\">"
             "<img src=\"/Bilder/logoGithub.png\">&nbspRepository mit dem Quellcode und der Dokumentation</a></li>\n"

--- a/Pflanzensensor/wifi_seite_start.h
+++ b/Pflanzensensor/wifi_seite_start.h
@@ -11,6 +11,8 @@
 #ifndef WIFI_SEITE_START_H
 #define WIFI_SEITE_START_H
 
+#include "logger.h"
+
 /**
  * @brief Sendet Sensordaten an den Webserver
  *
@@ -64,9 +66,8 @@ void sendeAnalogsensorDaten(int sensorNummer, const String& sensorName, const St
  * @brief Generiert und sendet die Startseite mit allen aktuellen Sensordaten
  */
 void WebseiteStartAusgeben() {
-  #if MODUL_DEBUG
-    Serial.println(F("# Beginn von WebsiteStartAusgeben()"));
-  #endif
+  logger.debug("# Beginn von WebsiteStartAusgeben()");
+
 
   Webserver.setContentLength(CONTENT_LENGTH_UNKNOWN);
   Webserver.send(200, F("text/html"), "");
@@ -124,9 +125,7 @@ void WebseiteStartAusgeben() {
     "<ul>\n"
     "<li><a href=\"/admin.html\">zur Administrationsseite</a></li>\n"));
 
-  #if MODUL_DEBUG
-    Webserver.sendContent_P(PSTR("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
-  #endif
+  Webserver.sendContent_P(PSTR("<li><a href=\"/debug.html\">zur Anzeige der Debuginformationen</a></li>\n"));
 
   Webserver.sendContent_P(PSTR(
     "<li><a href=\"https://www.github.com/Fabmobil/Pflanzensensor\" target=\"_blank\">"
@@ -139,9 +138,7 @@ void WebseiteStartAusgeben() {
   Webserver.sendContent_P(htmlFooter);
   Webserver.client().flush();
 
-  #if MODUL_DEBUG
-    Serial.println(F("# Ende von WebsiteStartAusgeben()"));
-  #endif
+  logger.debug("# Ende von WebsiteStartAusgeben()");
 }
 
 #endif // WIFI_SEITE_START_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,3 +28,4 @@ lib_deps =
 	vshymanskyy/Preferences @ ^2.1.0
 	LittleFS
 	bblanchon/ArduinoJson@^7.1.0
+	arduino-libraries/NTPClient@^3.2.1


### PR DESCRIPTION
Wir benutzen nun die Implementierung von logger um gleichzeitig auf der seriellen Schnittstelle, in einer Datei und auf dem Webinterface logs anzeigen zu können.